### PR TITLE
Shorten GitProjects cache duration

### DIFF
--- a/MillePortfolio/Pages/Index.cshtml.cs
+++ b/MillePortfolio/Pages/Index.cshtml.cs
@@ -44,7 +44,7 @@ namespace MillePortfolio.Pages
                     {
                         GitProjects = JsonConvert.DeserializeObject<List<GitProject>>(json);
 
-                        _memoryCache.Set("GitProjects", GitProjects, TimeSpan.FromHours(1));
+                        _memoryCache.Set("GitProjects", GitProjects, TimeSpan.FromMinutes(15));
                     }
                 }
             }


### PR DESCRIPTION
Reduced the caching duration for "GitProjects" in the memory cache from 1 hour to 15 minutes. This change ensures that the data stored in "GitProjects" is refreshed more frequently, now every 15 minutes instead of every hour.